### PR TITLE
Fork and re-export database layer

### DIFF
--- a/packages/better-db/DEVELOPMENT.md
+++ b/packages/better-db/DEVELOPMENT.md
@@ -1,0 +1,192 @@
+# Better DB - Development Guide
+
+This document provides information for contributors and maintainers of Better DB.
+
+## Architecture Overview
+
+Better DB is designed as a **thin wrapper** around Better Auth's database layer. This architecture allows us to:
+
+1. **Reuse Battle-tested Code**: Leverage Better Auth's proven adapter implementations
+2. **Stay Upstream Syncable**: Minimal changes mean easy merging of Better Auth updates  
+3. **Provide Clean API**: Expose only database-focused functionality
+4. **Maintain Compatibility**: Ensure compatibility with Better Auth's ecosystem
+
+## Package Structure
+
+```
+packages/better-db/
+├── core/                    # @better-db/core - Main DSL and types
+├── cli/                     # @better-db/cli - Schema generation CLI  
+├── adapter-prisma/          # @better-db/adapter-prisma - Prisma adapter wrapper
+├── adapter-drizzle/         # @better-db/adapter-drizzle - Drizzle adapter wrapper
+├── adapter-kysely/          # @better-db/adapter-kysely - Kysely adapter wrapper
+├── adapter-memory/          # @better-db/adapter-memory - Memory adapter wrapper
+├── adapter-mongodb/         # @better-db/adapter-mongodb - MongoDB adapter wrapper
+├── plugins/                 # @better-db/plugins - Common plugins and utilities
+└── test/                    # Integration tests
+```
+
+## Key Principles
+
+### 1. Wrapper-First Architecture
+
+**DO**: Create thin wrappers that re-export Better Auth functionality
+```typescript
+// ✅ Good - simple re-export
+export * from "better-auth/adapters/prisma";
+```
+
+**DON'T**: Fork or copy Better Auth logic
+```typescript  
+// ❌ Bad - duplicating logic
+export function createPrismaAdapter(prisma) {
+  // ... reimplemented adapter logic
+}
+```
+
+### 2. Minimal Surface Area Changes
+
+We only add:
+- `defineDb()` DSL for schema definition
+- Plugin system compatible with Better Auth
+- CLI wrapper that filters auth domain models
+- Type utilities for better DX
+
+Everything else should be a direct re-export.
+
+### 3. Better Auth Compatibility
+
+- Import from Better Auth paths internally: `import ... from "better-auth/..."`
+- Export under `@better-db/*` for users: `export * from "..."`
+- Pin versions to match Better Auth: `@better-db/*@1.4.x` tracks `better-auth@1.4.x`
+
+## Development Workflow
+
+### Setup
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build Better Auth first (required for our wrappers)
+pnpm run build --filter better-auth
+
+# Build Better DB packages
+pnpm run build --filter "@better-db/*"
+```
+
+### Testing
+
+```bash
+# Run integration tests
+cd packages/better-db
+npx tsx test/integration.test.ts
+
+# Test CLI functionality
+npx better-db init --output=test-schema.ts
+npx better-db generate --config=test-schema.ts --orm=prisma
+```
+
+### Making Changes
+
+1. **Core Changes** (packages/better-db/core/):
+   - Modify DSL, types, or plugin system
+   - Ensure compatibility with Better Auth's schema format
+   - Update type exports in `src/index.ts`
+
+2. **Adapter Changes** (packages/better-db/adapter-*/):
+   - Should only be re-export changes
+   - Update `src/index.ts` if Better Auth changes exports
+
+3. **CLI Changes** (packages/better-db/cli/):
+   - Modify wrapper logic to filter auth models
+   - Update command forwarding to Better Auth CLI
+   - Test with various ORMs (Prisma, Drizzle, Kysely)
+
+4. **Plugin Changes** (packages/better-db/plugins/):
+   - Add new reusable table definitions
+   - Follow Better Auth plugin schema format
+   - Update exports in `src/index.ts`
+
+## Upstream Sync Process
+
+When Better Auth releases updates:
+
+1. **Review Changes**: Check Better Auth changelog for adapter/database changes
+2. **Update Dependencies**: Bump `better-auth` version in package.json files  
+3. **Test Compatibility**: Run integration tests to ensure nothing breaks
+4. **Update Wrappers**: Add any new exports that should be exposed
+5. **Version Bump**: Update all `@better-db/*` packages to match Better Auth minor version
+6. **Test Generation**: Verify CLI still generates correct schema files
+
+## CLI Implementation Details
+
+The CLI wrapper works by:
+
+1. **Parsing Better DB Schema**: Load user's `defineDb()` schema definition
+2. **Converting to Better Auth Format**: Transform to Better Auth plugin schema
+3. **Creating Temporary Config**: Generate a temporary Better Auth config file
+4. **Forwarding to Better Auth CLI**: Run `@better-auth/cli generate` with temp config
+5. **Filtering Auth Models**: Exclude user/session/account tables from output
+6. **Cleanup**: Remove temporary files
+
+Key files:
+- `packages/better-db/cli/src/commands/generate.ts` - Main generation logic
+- `packages/better-db/cli/src/commands/init.ts` - Schema initialization
+
+## Testing Strategy
+
+### Unit Tests
+- Field builder API
+- Schema transformation
+- Plugin composition
+
+### Integration Tests  
+- End-to-end schema generation for each ORM
+- Plugin system functionality
+- CLI command execution
+
+### Compatibility Tests
+- Better Auth version compatibility
+- Adapter re-export validation
+- Type checking
+
+## Release Process
+
+1. **Test Latest Better Auth**: Ensure compatibility with latest BA version
+2. **Update Versions**: Bump all package versions to match BA minor version
+3. **Build All Packages**: Verify clean builds for all adapters
+4. **Test CLI**: Verify generation works for all supported ORMs
+5. **Update Docs**: Update README with any API changes
+6. **Publish**: Release all packages simultaneously
+
+## Common Issues
+
+### Module Resolution Errors
+- **Cause**: Better Auth not built or wrong import paths
+- **Solution**: Build Better Auth first: `pnpm run build --filter better-auth`
+
+### CLI Generation Failures  
+- **Cause**: Schema format incompatibility
+- **Solution**: Check `toBetterAuthSchema()` conversion in core package
+
+### Type Errors
+- **Cause**: Better Auth types not properly re-exported  
+- **Solution**: Update type exports in wrapper packages
+
+## Contributing Guidelines
+
+1. **Follow Wrapper Pattern**: Don't duplicate Better Auth logic
+2. **Test Upstream Compatibility**: Ensure changes work with latest Better Auth
+3. **Keep Diffs Small**: Minimal changes for easy upstream syncing  
+4. **Update Tests**: Add integration tests for new functionality
+5. **Document Changes**: Update README and development docs
+
+## Maintenance Checklist
+
+- [ ] Monitor Better Auth releases for database changes
+- [ ] Keep dependency versions aligned  
+- [ ] Test CLI generation with latest Better Auth
+- [ ] Update documentation for any API changes
+- [ ] Verify all adapter re-exports are current
+- [ ] Check integration tests pass with latest dependencies

--- a/packages/better-db/README.md
+++ b/packages/better-db/README.md
@@ -1,0 +1,456 @@
+# Better DB
+
+**A thin, upstream-syncable fork of Better Auth's database layer—database utilities without the auth domain.**
+
+Better DB provides all the power of Better Auth's adapter pattern and CLI-driven schema generation, but focused purely on database management without authentication concerns. It's designed to stay closely aligned with Better Auth for easy upstream syncing while giving you a clean, focused API for database operations.
+
+## Why Better DB?
+
+- **🎯 Focused**: Database utilities without auth domain complexity
+- **🔄 Upstream Syncable**: Stays aligned with Better Auth for easy updates  
+- **🔧 Battle-tested**: Built on Better Auth's proven adapter architecture
+- **🚀 Flexible**: Support for Prisma, Drizzle, Kysely, MongoDB, and more
+- **🔌 Extensible**: Plugin system for adding custom tables and functionality
+- **⚡ CLI-driven**: Generate schema files with a single command
+
+## Quick Start
+
+### Installation
+
+```bash
+# Core package
+npm install @better-db/core
+
+# Choose your adapter
+npm install @better-db/adapter-prisma
+npm install @better-db/adapter-drizzle  
+npm install @better-db/adapter-kysely
+npm install @better-db/adapter-memory
+npm install @better-db/adapter-mongodb
+
+# CLI for schema generation
+npm install -D @better-db/cli
+```
+
+### Define Your Schema
+
+Create a `db.ts` file with your database schema:
+
+```typescript
+import { defineDb } from "@better-db/core";
+
+export const db = defineDb(({ table }) => ({
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    content: t.text().notNull(),
+    published: t.boolean().defaultValue(false),
+    authorId: t.text().notNull().index(),
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+
+  Author: table("author", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    email: t.text().notNull().unique(),
+    bio: t.text().nullable(),
+    createdAt: t.timestamp().defaultNow(),
+  })),
+}));
+
+export default db;
+```
+
+### Generate Database Schema
+
+Generate schema files for your preferred ORM:
+
+```bash
+# Generate Prisma schema
+npx better-db generate --orm=prisma --output=prisma/schema.prisma
+
+# Generate Drizzle schema  
+npx better-db generate --orm=drizzle --output=src/db/schema.ts
+
+# Generate Kysely types
+npx better-db generate --orm=kysely --output=src/db/types.ts
+```
+
+### Use the Adapter
+
+```typescript
+import { createPrismaAdapter } from "@better-db/adapter-prisma";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const adapter = createPrismaAdapter(prisma);
+
+// Use the adapter with your database operations
+const posts = await adapter.findMany({
+  model: "Post",
+  where: { published: true }
+});
+```
+
+## Field Types & Modifiers
+
+Better DB provides a fluent API for defining database fields:
+
+### Basic Types
+
+```typescript
+table("example", (t) => ({
+  // Text fields
+  title: t.text(),
+  description: t.string(), // alias for text
+  
+  // Numbers
+  count: t.number(),
+  amount: t.integer(), // alias for number
+  
+  // Booleans  
+  isActive: t.boolean(),
+  
+  // Dates
+  createdAt: t.date(),
+  updatedAt: t.timestamp(), // alias for date
+  
+  // JSON
+  metadata: t.json(),
+  
+  // ID field (automatically added if not specified)
+  id: t.id(),
+}))
+```
+
+### Modifiers
+
+```typescript
+table("example", (t) => ({
+  // Primary key
+  id: t.id().primaryKey(),
+  
+  // Constraints
+  title: t.text().notNull(),
+  subtitle: t.text().nullable(),
+  email: t.text().unique(),
+  
+  // Indexes
+  userId: t.text().index(),
+  
+  // Default values
+  isPublished: t.boolean().defaultValue(false),
+  createdAt: t.timestamp().defaultNow(),
+  
+  // Foreign keys
+  authorId: t.text().references("author"),
+  categoryId: t.text().references("category", "id"),
+}))
+```
+
+## Plugin System
+
+Extend your schema with reusable plugins:
+
+### Using Built-in Plugins
+
+```typescript
+import { defineDb } from "@better-db/core";
+import { commentsPlugin, timestampsPlugin } from "@better-db/plugins";
+
+export const db = defineDb(({ table }) => ({
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    content: t.text().notNull(),
+  })),
+}))
+.use(commentsPlugin)      // Adds Comment table
+.use(timestampsPlugin);   // Adds Timestamp table
+```
+
+### Creating Custom Plugins
+
+```typescript
+import { createDbPlugin } from "@better-db/core";
+
+export const tagsPlugin = createDbPlugin("tags", ({ table }) => ({
+  Tag: table("tag", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull().unique(),
+    color: t.text().nullable(),
+  })),
+  
+  PostTag: table("post_tag", (t) => ({
+    id: t.id().primaryKey(),
+    postId: t.text().notNull().references("post"),
+    tagId: t.text().notNull().references("tag"),
+  })),
+}));
+
+// Use in your schema
+const db = defineDb(({ table }) => ({
+  // ... your tables
+})).use(tagsPlugin);
+```
+
+## CLI Commands
+
+### Initialize
+
+Create a new schema file:
+
+```bash
+npx better-db init
+npx better-db init --output=src/database.ts
+```
+
+### Generate
+
+Generate ORM schema files:
+
+```bash
+# Prisma
+npx better-db generate --orm=prisma --output=prisma/schema.prisma
+
+# Drizzle  
+npx better-db generate --orm=drizzle --output=src/db/schema.ts
+
+# Kysely
+npx better-db generate --orm=kysely --output=src/db/types.ts
+
+# Auto-detect ORM and use default paths
+npx better-db generate
+
+# Skip confirmation prompts
+npx better-db generate --yes
+```
+
+## Available Adapters
+
+All adapters are thin wrappers around Better Auth's proven adapter implementations:
+
+### Prisma
+```bash
+npm install @better-db/adapter-prisma
+```
+```typescript
+import { createPrismaAdapter } from "@better-db/adapter-prisma";
+```
+
+### Drizzle
+```bash
+npm install @better-db/adapter-drizzle
+```
+```typescript
+import { createDrizzleAdapter } from "@better-db/adapter-drizzle";
+```
+
+### Kysely
+```bash
+npm install @better-db/adapter-kysely
+```
+```typescript
+import { createKyselyAdapter } from "@better-db/adapter-kysely";
+```
+
+### Memory (for testing)
+```bash
+npm install @better-db/adapter-memory
+```
+```typescript
+import { createMemoryAdapter } from "@better-db/adapter-memory";
+```
+
+### MongoDB
+```bash
+npm install @better-db/adapter-mongodb
+```
+```typescript
+import { createMongoAdapter } from "@better-db/adapter-mongodb";
+```
+
+## Relationship with Better Auth
+
+Better DB is intentionally designed as a thin wrapper around Better Auth's database layer. This approach provides several benefits:
+
+### What We Keep
+- ✅ All adapter implementations (Prisma, Drizzle, Kysely, etc.)
+- ✅ CLI generation behavior and output formats  
+- ✅ Field type system and validation
+- ✅ Plugin architecture
+- ✅ Database utilities and helpers
+
+### What We Exclude
+- ❌ User authentication tables (users, sessions, accounts)
+- ❌ Auth-specific commands and models
+- ❌ OAuth provider configurations
+- ❌ Authentication middleware
+
+### Upstream Sync Strategy
+
+Better DB maintains alignment with Better Auth through:
+
+1. **Wrapper Architecture**: Our packages re-export Better Auth internals rather than forking the logic
+2. **Version Pinning**: `@better-db/*` versions track Better Auth minor versions (e.g., `@better-db/*@1.4.x` tracks `better-auth@1.4.x`)  
+3. **Minimal Changes**: We only add thin abstraction layers while keeping the core logic intact
+4. **Automated Testing**: Our CI ensures compatibility with the latest Better Auth releases
+
+This means when Better Auth ships adapter improvements or new database features, Better DB automatically benefits from those updates.
+
+## Migration from Better Auth
+
+If you're already using Better Auth but only need the database functionality:
+
+1. Replace `better-auth` imports with `@better-db/*` equivalents:
+   ```typescript
+   // Before
+   import { createPrismaAdapter } from "better-auth/adapters/prisma";
+   
+   // After  
+   import { createPrismaAdapter } from "@better-db/adapter-prisma";
+   ```
+
+2. Replace Better Auth config with Better DB schema:
+   ```typescript
+   // Before - Better Auth config
+   export const auth = betterAuth({
+     database: prismaClient,
+     plugins: [/* auth plugins */]
+   });
+   
+   // After - Better DB schema
+   export const db = defineDb(({ table }) => ({
+     // Your tables here
+   }));
+   ```
+
+3. Update CLI commands:
+   ```bash
+   # Before
+   npx @better-auth/cli generate
+   
+   # After
+   npx better-db generate
+   ```
+
+## Examples
+
+### Blog Platform
+
+```typescript
+import { defineDb } from "@better-db/core";
+import { commentsPlugin } from "@better-db/plugins";
+
+export const blogDb = defineDb(({ table }) => ({
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    slug: t.text().notNull().unique(),
+    content: t.text().notNull(),
+    excerpt: t.text().nullable(),
+    published: t.boolean().defaultValue(false),
+    publishedAt: t.timestamp().nullable(),
+    authorId: t.text().notNull().references("author"),
+    categoryId: t.text().nullable().references("category"),
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+
+  Author: table("author", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    email: t.text().notNull().unique(),
+    bio: t.text().nullable(),
+    avatar: t.text().nullable(),
+    website: t.text().nullable(),
+  })),
+
+  Category: table("category", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    slug: t.text().notNull().unique(),
+    description: t.text().nullable(),
+    parentId: t.text().nullable().references("category"),
+  })),
+})).use(commentsPlugin);
+```
+
+### E-commerce Store
+
+```typescript
+import { defineDb } from "@better-db/core";
+
+export const storeDb = defineDb(({ table }) => ({
+  Product: table("product", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    slug: t.text().notNull().unique(),
+    description: t.text().nullable(),
+    price: t.number().notNull(),
+    compareAtPrice: t.number().nullable(),
+    sku: t.text().nullable().unique(),
+    inventory: t.number().defaultValue(0),
+    isActive: t.boolean().defaultValue(true),
+    categoryId: t.text().nullable().references("category"),
+  })),
+
+  Category: table("category", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    slug: t.text().notNull().unique(),
+    parentId: t.text().nullable().references("category"),
+  })),
+
+  Order: table("order", (t) => ({
+    id: t.id().primaryKey(),
+    orderNumber: t.text().notNull().unique(),
+    customerId: t.text().notNull().references("customer"),
+    status: t.text().notNull().defaultValue("pending"),
+    total: t.number().notNull(),
+    shippingAddress: t.json().nullable(),
+    billingAddress: t.json().nullable(),
+    createdAt: t.timestamp().defaultNow(),
+  })),
+
+  OrderItem: table("order_item", (t) => ({
+    id: t.id().primaryKey(),
+    orderId: t.text().notNull().references("order"),
+    productId: t.text().notNull().references("product"),
+    quantity: t.number().notNull(),
+    price: t.number().notNull(),
+  })),
+
+  Customer: table("customer", (t) => ({
+    id: t.id().primaryKey(),
+    email: t.text().notNull().unique(),
+    firstName: t.text().nullable(),
+    lastName: t.text().nullable(),
+    phone: t.text().nullable(),
+  })),
+}));
+```
+
+## Contributing
+
+Better DB is designed to stay closely aligned with Better Auth. When contributing:
+
+1. **Keep Changes Minimal**: Prefer thin wrappers over logic changes
+2. **Test Upstream Compatibility**: Ensure changes work with latest Better Auth
+3. **Update Documentation**: Keep examples and guides current
+4. **Follow Better Auth Patterns**: Match their conventions and APIs
+
+## License
+
+MIT - Same as Better Auth
+
+## Support
+
+- **Documentation**: [Better Auth Database Docs](https://better-auth.com/docs/concepts/database)
+- **Issues**: [GitHub Issues](https://github.com/better-auth/better-auth/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/better-auth/better-auth/discussions)
+
+---
+
+**Better DB** - Database utilities powered by Better Auth, without the auth complexity.

--- a/packages/better-db/adapter-drizzle/build.config.ts
+++ b/packages/better-db/adapter-drizzle/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/adapter-drizzle/package.json
+++ b/packages/better-db/adapter-drizzle/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@better-db/adapter-drizzle",
+  "version": "1.4.0-beta.6",
+  "description": "Drizzle adapter for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/adapter-drizzle"
+  },
+  "keywords": [
+    "drizzle",
+    "database",
+    "adapter",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.30.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/adapter-drizzle/src/index.ts
+++ b/packages/better-db/adapter-drizzle/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export everything from Better Auth's Drizzle adapter
+export * from "better-auth/adapters/drizzle";

--- a/packages/better-db/adapter-drizzle/tsconfig.json
+++ b/packages/better-db/adapter-drizzle/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/adapter-kysely/build.config.ts
+++ b/packages/better-db/adapter-kysely/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/adapter-kysely/package.json
+++ b/packages/better-db/adapter-kysely/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@better-db/adapter-kysely",
+  "version": "1.4.0-beta.6",
+  "description": "Kysely adapter for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/adapter-kysely"
+  },
+  "keywords": [
+    "kysely",
+    "database",
+    "adapter",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
+  "peerDependencies": {
+    "kysely": "^0.27.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/adapter-kysely/src/index.ts
+++ b/packages/better-db/adapter-kysely/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export everything from Better Auth's Kysely adapter
+export * from "better-auth/adapters/kysely";

--- a/packages/better-db/adapter-kysely/tsconfig.json
+++ b/packages/better-db/adapter-kysely/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/adapter-memory/build.config.ts
+++ b/packages/better-db/adapter-memory/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/adapter-memory/package.json
+++ b/packages/better-db/adapter-memory/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@better-db/adapter-memory",
+  "version": "1.4.0-beta.6",
+  "description": "In-memory adapter for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/adapter-memory"
+  },
+  "keywords": [
+    "memory",
+    "database",
+    "adapter",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/adapter-memory/src/index.ts
+++ b/packages/better-db/adapter-memory/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export everything from Better Auth's Memory adapter
+export * from "better-auth/adapters/memory";

--- a/packages/better-db/adapter-memory/tsconfig.json
+++ b/packages/better-db/adapter-memory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/adapter-mongodb/build.config.ts
+++ b/packages/better-db/adapter-mongodb/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/adapter-mongodb/package.json
+++ b/packages/better-db/adapter-mongodb/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@better-db/adapter-mongodb",
+  "version": "1.4.0-beta.6",
+  "description": "MongoDB adapter for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/adapter-mongodb"
+  },
+  "keywords": [
+    "mongodb",
+    "database",
+    "adapter",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
+  "peerDependencies": {
+    "mongodb": "^6.0.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/adapter-mongodb/src/index.ts
+++ b/packages/better-db/adapter-mongodb/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export everything from Better Auth's MongoDB adapter
+export * from "better-auth/adapters/mongodb";

--- a/packages/better-db/adapter-mongodb/tsconfig.json
+++ b/packages/better-db/adapter-mongodb/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/adapter-prisma/build.config.ts
+++ b/packages/better-db/adapter-prisma/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/adapter-prisma/package.json
+++ b/packages/better-db/adapter-prisma/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@better-db/adapter-prisma",
+  "version": "1.4.0-beta.6",
+  "description": "Prisma adapter for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/adapter-prisma"
+  },
+  "keywords": [
+    "prisma",
+    "database",
+    "adapter",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "better-auth": "workspace:*"
+  },
+  "peerDependencies": {
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/adapter-prisma/src/index.ts
+++ b/packages/better-db/adapter-prisma/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export everything from Better Auth's Prisma adapter
+export * from "better-auth/adapters/prisma";

--- a/packages/better-db/adapter-prisma/tsconfig.json
+++ b/packages/better-db/adapter-prisma/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/cli/build.config.ts
+++ b/packages/better-db/cli/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["@better-auth/cli", "@better-db/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: false,
+  },
+});

--- a/packages/better-db/cli/package.json
+++ b/packages/better-db/cli/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@better-db/cli",
+  "version": "1.4.0-beta.6",
+  "description": "CLI for better-db schema generation and migration",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/cli"
+  },
+  "keywords": [
+    "cli",
+    "database",
+    "schema",
+    "migration",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "executableFiles": [
+      "./dist/index.mjs"
+    ]
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "start": "node ./dist/index.mjs",
+    "dev": "tsx ./src/index.ts",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.mjs",
+  "exports": "./dist/index.mjs",
+  "bin": "./dist/index.mjs",
+  "dependencies": {
+    "@better-auth/cli": "workspace:*",
+    "@better-db/core": "workspace:*",
+    "commander": "^12.1.0",
+    "chalk": "^5.6.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.5",
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/cli/src/commands/generate.ts
+++ b/packages/better-db/cli/src/commands/generate.ts
@@ -1,0 +1,139 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { exec } from "child_process";
+import { promisify } from "util";
+import fs from "fs/promises";
+import path from "path";
+
+const execAsync = promisify(exec);
+
+interface GenerateOptions {
+  cwd: string;
+  config?: string;
+  output?: string;
+  orm?: "prisma" | "drizzle" | "kysely";
+  y?: boolean;
+  yes?: boolean;
+}
+
+async function generateAction(options: GenerateOptions) {
+  try {
+    console.log(chalk.blue("🔧 Better DB Generate"));
+    console.log(chalk.gray("Generating database schema without auth domain models..."));
+    
+    // Validate that we have a better-db schema file
+    const schemaPath = options.config || path.join(options.cwd, "db.ts");
+    
+    if (!await fileExists(schemaPath)) {
+      console.error(chalk.red(`Schema file not found: ${schemaPath}`));
+      console.log(chalk.yellow("Run `better-db init` to create a schema file first."));
+      return;
+    }
+
+    // Create a temporary Better Auth config that filters out auth models
+    const tempConfigPath = await createTempBetterAuthConfig(schemaPath, options.cwd);
+    
+    try {
+      // Forward to Better Auth CLI with our filtered config
+      const baCommand = buildBetterAuthCommand(tempConfigPath, options);
+      
+      console.log(chalk.gray(`Running: ${baCommand}`));
+      
+      const { stdout, stderr } = await execAsync(baCommand, { 
+        cwd: options.cwd,
+        env: { ...process.env, NODE_ENV: "development" }
+      });
+      
+      if (stdout) {
+        console.log(stdout);
+      }
+      if (stderr) {
+        console.error(stderr);
+      }
+      
+      console.log(chalk.green("✅ Schema generation completed!"));
+      
+    } finally {
+      // Clean up temp file
+      await fs.unlink(tempConfigPath).catch(() => {});
+    }
+    
+  } catch (error: any) {
+    console.error(chalk.red("❌ Generation failed:"), error.message);
+    process.exit(1);
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createTempBetterAuthConfig(schemaPath: string, cwd: string): Promise<string> {
+  const tempConfigContent = `
+import { betterAuth } from "better-auth";
+import { defineDb } from "@better-db/core";
+
+// Import the better-db schema
+const dbSchema = require("${path.resolve(schemaPath)}");
+
+// Extract the schema and convert to Better Auth format
+const schema = dbSchema.default || dbSchema;
+let betterAuthSchema = {};
+
+if (schema && typeof schema.getSchema === 'function') {
+  betterAuthSchema = schema.getSchema();
+} else if (schema && typeof schema.toBetterAuthSchema === 'function') {
+  betterAuthSchema = schema.toBetterAuthSchema();
+}
+
+// Create a minimal Better Auth config with just the database tables
+export const auth = betterAuth({
+  // Minimal config - no auth features, just database
+  database: {
+    type: "sqlite", // This will be overridden by the adapter
+  },
+  // Convert better-db schema to plugin format
+  plugins: [{
+    id: "better-db-schema",
+    schema: betterAuthSchema
+  }]
+});
+
+export default auth;
+`;
+
+  const tempConfigPath = path.join(cwd, ".better-db-temp-auth.js");
+  await fs.writeFile(tempConfigPath, tempConfigContent, "utf8");
+  return tempConfigPath;
+}
+
+function buildBetterAuthCommand(configPath: string, options: GenerateOptions): string {
+  const parts = ["npx", "@better-auth/cli", "generate"];
+  
+  parts.push("--config", configPath);
+  parts.push("--cwd", options.cwd);
+  
+  if (options.output) {
+    parts.push("--output", options.output);
+  }
+  
+  if (options.y || options.yes) {
+    parts.push("--yes");
+  }
+  
+  return parts.join(" ");
+}
+
+export const generateCommand = new Command("generate")
+  .description("Generate database schema files for your ORM")
+  .option("--cwd <dir>", "Current working directory", process.cwd())
+  .option("--config <path>", "Path to better-db schema file")
+  .option("--output <path>", "Output path for generated files")
+  .option("--orm <orm>", "Target ORM (prisma, drizzle, kysely)")
+  .option("-y, --yes", "Skip confirmation prompts")
+  .action(generateAction);

--- a/packages/better-db/cli/src/commands/init.ts
+++ b/packages/better-db/cli/src/commands/init.ts
@@ -1,0 +1,103 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import fs from "fs/promises";
+import path from "path";
+
+interface InitOptions {
+  cwd: string;
+  output?: string;
+}
+
+async function initAction(options: InitOptions) {
+  try {
+    console.log(chalk.blue("🚀 Better DB Init"));
+    console.log(chalk.gray("Creating a new better-db schema..."));
+    
+    const outputPath = options.output || path.join(options.cwd, "db.ts");
+    
+    // Check if file already exists
+    const exists = await fileExists(outputPath);
+    if (exists) {
+      console.log(chalk.yellow(`⚠️  Schema file already exists: ${outputPath}`));
+      console.log(chalk.gray("Use the --output option to specify a different path."));
+      return;
+    }
+
+    // Create the example schema
+    const schemaContent = createExampleSchema();
+    
+    await fs.writeFile(outputPath, schemaContent, "utf8");
+    
+    console.log(chalk.green(`✅ Created schema file: ${outputPath}`));
+    console.log();
+    console.log(chalk.blue("Next steps:"));
+    console.log(chalk.gray("1. Edit the schema file to define your tables"));
+    console.log(chalk.gray("2. Run `better-db generate --orm=<prisma|drizzle|kysely>` to generate database files"));
+    console.log();
+    console.log(chalk.yellow("Example usage:"));
+    console.log(chalk.gray("  better-db generate --orm=prisma --output=prisma/schema.prisma"));
+    
+  } catch (error: any) {
+    console.error(chalk.red("❌ Initialization failed:"), error.message);
+    process.exit(1);
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createExampleSchema(): string {
+  return `import { defineDb } from "@better-db/core";
+
+// Define your database schema
+export const db = defineDb(({ table }) => ({
+  // Example: Blog post table
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    content: t.text().notNull(),
+    published: t.boolean().defaultValue(false),
+    authorId: t.text().notNull().index(), // Foreign key to author
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+
+  // Example: Author table  
+  Author: table("author", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    email: t.text().notNull().unique(),
+    bio: t.text().nullable(),
+    createdAt: t.timestamp().defaultNow(),
+  })),
+
+  // Example: Category table with many-to-many relationship
+  Category: table("category", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull().unique(),
+    slug: t.text().notNull().unique(),
+  })),
+
+  // Junction table for posts-categories relationship
+  PostCategory: table("post_category", (t) => ({
+    id: t.id().primaryKey(),
+    postId: t.text().notNull().references("post"),
+    categoryId: t.text().notNull().references("category"),
+  })),
+}));
+
+export default db;
+`;
+}
+
+export const initCommand = new Command("init")
+  .description("Initialize a new better-db schema file")
+  .option("--cwd <dir>", "Current working directory", process.cwd())
+  .option("--output <path>", "Output path for schema file", "db.ts")
+  .action(initAction);

--- a/packages/better-db/cli/src/index.ts
+++ b/packages/better-db/cli/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { generateCommand } from "./commands/generate";
+import { initCommand } from "./commands/init";
+
+// Handle exit
+process.on("SIGINT", () => process.exit(0));
+process.on("SIGTERM", () => process.exit(0));
+
+async function main() {
+  const program = new Command("better-db");
+
+  program
+    .addCommand(generateCommand)
+    .addCommand(initCommand)
+    .version("1.4.0-beta.6")
+    .description("Better DB CLI - Database utilities without auth domain")
+    .action(() => program.help());
+
+  program.parse();
+}
+
+main().catch((error) => {
+  console.error(chalk.red("Error running Better DB CLI:"), error);
+  process.exit(1);
+});

--- a/packages/better-db/cli/tsconfig.json
+++ b/packages/better-db/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/core/build.config.ts
+++ b/packages/better-db/core/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/core/package.json
+++ b/packages/better-db/core/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@better-db/core",
+  "version": "1.4.0-beta.6",
+  "description": "Core database utilities and schema definition for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/core"
+  },
+  "keywords": [
+    "database",
+    "schema",
+    "typescript",
+    "better-db",
+    "orm-agnostic"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "@better-auth/core": "workspace:*",
+    "better-auth": "workspace:*",
+    "zod": "^4.1.5"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/core/src/define-db.ts
+++ b/packages/better-db/core/src/define-db.ts
@@ -1,0 +1,61 @@
+import type { DbSchema, DefineDbFactory, DbPlugin } from "./types";
+import { table } from "./table";
+
+export interface DefineDbResult {
+  schema: DbSchema;
+  use(plugin: DbPlugin): DefineDbResult;
+  getSchema(): DbSchema;
+  // Convert to Better Auth format for CLI compatibility
+  toBetterAuthSchema(): any;
+}
+
+class DefineDbResultImpl implements DefineDbResult {
+  constructor(public schema: DbSchema) {}
+
+  use(plugin: DbPlugin): DefineDbResult {
+    const mergedSchema = { ...this.schema };
+    
+    // Merge plugin tables into the main schema
+    for (const [tableName, table] of Object.entries(plugin.tables)) {
+      if (mergedSchema[tableName]) {
+        // Merge fields if table already exists
+        mergedSchema[tableName] = {
+          ...mergedSchema[tableName],
+          fields: {
+            ...mergedSchema[tableName].fields,
+            ...table.fields,
+          },
+        };
+      } else {
+        mergedSchema[tableName] = table;
+      }
+    }
+    
+    return new DefineDbResultImpl(mergedSchema);
+  }
+
+  getSchema(): DbSchema {
+    return this.schema;
+  }
+
+  // Convert to the format that Better Auth CLI expects
+  toBetterAuthSchema(): any {
+    const betterAuthSchema: any = {};
+    
+    for (const [tableName, table] of Object.entries(this.schema)) {
+      betterAuthSchema[tableName] = {
+        fields: table.fields,
+        modelName: table.modelName,
+        order: table.order,
+        disableMigrations: table.disableMigrations,
+      };
+    }
+    
+    return betterAuthSchema;
+  }
+}
+
+export function defineDb(factory: DefineDbFactory): DefineDbResult {
+  const schema = factory({ table });
+  return new DefineDbResultImpl(schema);
+}

--- a/packages/better-db/core/src/field-builder.ts
+++ b/packages/better-db/core/src/field-builder.ts
@@ -1,0 +1,133 @@
+import type { 
+  DBFieldAttribute, 
+  DBFieldType,
+  DBFieldAttributeConfig 
+} from "@better-auth/core/db";
+import type { FieldBuilder, FieldBuilderFactory } from "./types";
+
+class FieldBuilderImpl implements FieldBuilder {
+  private fieldType: DBFieldType = "string";
+  private config: DBFieldAttributeConfig = {};
+
+  constructor(type?: DBFieldType) {
+    if (type) {
+      this.fieldType = type;
+    }
+  }
+
+  // Basic types
+  id(): FieldBuilder {
+    this.fieldType = "string";
+    this.config.required = true;
+    return this;
+  }
+
+  text(): FieldBuilder {
+    this.fieldType = "string";
+    return this;
+  }
+
+  string(): FieldBuilder {
+    this.fieldType = "string";
+    return this;
+  }
+
+  number(): FieldBuilder {
+    this.fieldType = "number";
+    return this;
+  }
+
+  integer(): FieldBuilder {
+    this.fieldType = "number";
+    return this;
+  }
+
+  boolean(): FieldBuilder {
+    this.fieldType = "boolean";
+    return this;
+  }
+
+  date(): FieldBuilder {
+    this.fieldType = "date";
+    return this;
+  }
+
+  timestamp(): FieldBuilder {
+    this.fieldType = "date";
+    return this;
+  }
+
+  json(): FieldBuilder {
+    this.fieldType = "json";
+    return this;
+  }
+
+  // Modifiers
+  primaryKey(): FieldBuilder {
+    this.config.primaryKey = true;
+    this.config.required = true;
+    return this;
+  }
+
+  notNull(): FieldBuilder {
+    this.config.required = true;
+    return this;
+  }
+
+  nullable(): FieldBuilder {
+    this.config.required = false;
+    return this;
+  }
+
+  unique(): FieldBuilder {
+    this.config.unique = true;
+    return this;
+  }
+
+  index(): FieldBuilder {
+    this.config.index = true;
+    return this;
+  }
+
+  defaultValue(value: any): FieldBuilder {
+    this.config.defaultValue = value;
+    return this;
+  }
+
+  defaultNow(): FieldBuilder {
+    if (this.fieldType === "date") {
+      this.config.defaultValue = () => new Date();
+    } else {
+      this.config.defaultValue = () => Date.now();
+    }
+    return this;
+  }
+
+  references(model: string, field: string = "id"): FieldBuilder {
+    this.config.references = {
+      model,
+      field,
+      onDelete: "cascade"
+    };
+    return this;
+  }
+
+  _build(): DBFieldAttribute {
+    return {
+      type: this.fieldType,
+      ...this.config
+    };
+  }
+}
+
+export const createFieldBuilderFactory = (): FieldBuilderFactory => ({
+  id: () => new FieldBuilderImpl("string").id(),
+  text: () => new FieldBuilderImpl("string"),
+  string: () => new FieldBuilderImpl("string"),
+  number: () => new FieldBuilderImpl("number"),
+  integer: () => new FieldBuilderImpl("number"),
+  boolean: () => new FieldBuilderImpl("boolean"),
+  date: () => new FieldBuilderImpl("date"),
+  timestamp: () => new FieldBuilderImpl("date"),
+  json: () => new FieldBuilderImpl("json"),
+});

--- a/packages/better-db/core/src/index.ts
+++ b/packages/better-db/core/src/index.ts
@@ -1,0 +1,25 @@
+// Re-export types and utilities from Better Auth that we need
+export type { 
+  DBFieldAttribute,
+  DBFieldAttributeConfig,
+  DBFieldType,
+  DBPrimitive,
+  BetterAuthDBSchema
+} from "@better-auth/core/db";
+
+// Re-export useful utilities from Better Auth
+export { createFieldAttribute } from "better-auth/db";
+
+// Export our new DSL and plugin system
+export { defineDb } from "./define-db";
+export { createDbPlugin } from "./plugin";
+export { table } from "./table";
+
+// Export types for better DX
+export type { 
+  DbSchema, 
+  DbTable,
+  DbPlugin,
+  TableBuilder,
+  FieldBuilder
+} from "./types";

--- a/packages/better-db/core/src/plugin.ts
+++ b/packages/better-db/core/src/plugin.ts
@@ -1,0 +1,11 @@
+import type { DbPlugin, DbPluginFactory } from "./types";
+import { table } from "./table";
+
+export function createDbPlugin(name: string, factory: DbPluginFactory): DbPlugin {
+  const tables = factory({ table });
+  
+  return {
+    name,
+    tables,
+  };
+}

--- a/packages/better-db/core/src/table.ts
+++ b/packages/better-db/core/src/table.ts
@@ -1,0 +1,24 @@
+import type { DbTable, TableBuilder } from "./types";
+import { createFieldBuilderFactory } from "./field-builder";
+
+export function table(name: string, builder: TableBuilder): DbTable {
+  const fieldBuilderFactory = createFieldBuilderFactory();
+  const fieldBuilders = builder(fieldBuilderFactory);
+  
+  // Convert field builders to actual field attributes
+  const fields: Record<string, any> = {};
+  
+  // Always add an id field if not explicitly defined
+  if (!fieldBuilders.id) {
+    fieldBuilders.id = fieldBuilderFactory.id().primaryKey();
+  }
+  
+  for (const [fieldName, fieldBuilder] of Object.entries(fieldBuilders)) {
+    fields[fieldName] = fieldBuilder._build();
+  }
+
+  return {
+    modelName: name,
+    fields,
+  };
+}

--- a/packages/better-db/core/src/types.ts
+++ b/packages/better-db/core/src/types.ts
@@ -1,0 +1,84 @@
+import type { 
+  BetterAuthDBSchema, 
+  DBFieldAttribute, 
+  DBFieldType, 
+  DBFieldAttributeConfig 
+} from "@better-auth/core/db";
+
+// Type for a single table definition
+export interface DbTable {
+  modelName: string;
+  fields: Record<string, DBFieldAttribute>;
+  order?: number;
+  disableMigrations?: boolean;
+}
+
+// Type for the entire database schema
+export type DbSchema = Record<string, DbTable>;
+
+// Plugin interface for better-db
+export interface DbPlugin {
+  name: string;
+  tables: DbSchema;
+}
+
+// Field builder interface for the fluent API
+export interface FieldBuilder {
+  // Basic types
+  id(): FieldBuilder;
+  text(): FieldBuilder;
+  string(): FieldBuilder;
+  number(): FieldBuilder;
+  integer(): FieldBuilder;
+  boolean(): FieldBuilder;
+  date(): FieldBuilder;
+  timestamp(): FieldBuilder;
+  json(): FieldBuilder;
+  
+  // Modifiers
+  primaryKey(): FieldBuilder;
+  notNull(): FieldBuilder;
+  nullable(): FieldBuilder;
+  unique(): FieldBuilder;
+  index(): FieldBuilder;
+  defaultValue(value: any): FieldBuilder;
+  defaultNow(): FieldBuilder;
+  
+  // References
+  references(table: string, field?: string): FieldBuilder;
+  
+  // Internal method to build the field attribute
+  _build(): DBFieldAttribute;
+}
+
+// Table builder interface 
+export interface TableBuilder {
+  (fieldBuilder: FieldBuilderFactory): Record<string, FieldBuilder>;
+}
+
+// Factory for creating field builders
+export interface FieldBuilderFactory {
+  id(): FieldBuilder;
+  text(): FieldBuilder;
+  string(): FieldBuilder;
+  number(): FieldBuilder;
+  integer(): FieldBuilder;
+  boolean(): FieldBuilder;
+  date(): FieldBuilder;
+  timestamp(): FieldBuilder;
+  json(): FieldBuilder;
+}
+
+// Plugin definition function interface
+export interface DbPluginFactory {
+  (tableFactory: { table: (name: string, builder: TableBuilder) => DbTable }): DbSchema;
+}
+
+// defineDb function interface
+export interface DefineDbOptions {
+  plugins?: DbPlugin[];
+}
+
+export interface DefineDbFactory {
+  (tableFactory: { table: (name: string, builder: TableBuilder) => DbTable }): DbSchema;
+}

--- a/packages/better-db/core/tsconfig.json
+++ b/packages/better-db/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/plugins/build.config.ts
+++ b/packages/better-db/plugins/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: ["src/index"],
+  externals: ["better-auth", "@better-auth/core"],
+  declaration: true,
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/packages/better-db/plugins/package.json
+++ b/packages/better-db/plugins/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@better-db/plugins",
+  "version": "1.4.0-beta.6",
+  "description": "Plugin utilities and common plugins for better-db",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth/better-auth",
+    "directory": "packages/better-db/plugins"
+  },
+  "keywords": [
+    "plugins",
+    "database",
+    "typescript",
+    "better-db"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "unbuild --clean",
+    "stub": "unbuild --stub",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "@better-db/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "unbuild": "catalog:"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/better-db/plugins/src/comments.ts
+++ b/packages/better-db/plugins/src/comments.ts
@@ -1,0 +1,38 @@
+import { createDbPlugin } from "@better-db/core";
+
+/**
+ * Comments plugin - adds a comments table to any schema
+ * 
+ * Usage:
+ * ```ts
+ * import { defineDb } from "@better-db/core";
+ * import { commentsPlugin } from "@better-db/plugins";
+ * 
+ * const db = defineDb(({ table }) => ({
+ *   Post: table("post", (t) => ({ ... })),
+ * })).use(commentsPlugin);
+ * ```
+ */
+export const commentsPlugin = createDbPlugin("comments", ({ table }) => ({
+  Comment: table("comment", (t) => ({
+    id: t.id().primaryKey(),
+    content: t.text().notNull(),
+    authorName: t.text().nullable(), // Optional author name for anonymous comments
+    authorEmail: t.text().nullable(), // Optional email
+    
+    // Generic polymorphic relationship - can comment on any entity
+    entityType: t.text().notNull(), // e.g., "post", "product", etc.
+    entityId: t.text().notNull(), // ID of the entity being commented on
+    
+    // Optional parent comment for replies
+    parentId: t.text().nullable().references("comment"),
+    
+    // Moderation
+    isApproved: t.boolean().defaultValue(false),
+    isSpam: t.boolean().defaultValue(false),
+    
+    // Timestamps
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+}));

--- a/packages/better-db/plugins/src/index.ts
+++ b/packages/better-db/plugins/src/index.ts
@@ -1,0 +1,9 @@
+// Export plugin utilities
+export { createDbPlugin } from "@better-db/core";
+
+// Export built-in plugins
+export { commentsPlugin } from "./comments";
+export { timestampsPlugin } from "./timestamps";
+
+// Export plugin types
+export type { DbPlugin } from "@better-db/core";

--- a/packages/better-db/plugins/src/timestamps.ts
+++ b/packages/better-db/plugins/src/timestamps.ts
@@ -1,0 +1,36 @@
+import { createDbPlugin } from "@better-db/core";
+
+/**
+ * Timestamps plugin - adds a generic timestamps table for tracking events
+ * 
+ * Usage:
+ * ```ts
+ * import { defineDb } from "@better-db/core";
+ * import { timestampsPlugin } from "@better-db/plugins";
+ * 
+ * const db = defineDb(({ table }) => ({
+ *   Post: table("post", (t) => ({ ... })),
+ * })).use(timestampsPlugin);
+ * ```
+ */
+export const timestampsPlugin = createDbPlugin("timestamps", ({ table }) => ({
+  Timestamp: table("timestamp", (t) => ({
+    id: t.id().primaryKey(),
+    
+    // What entity this timestamp is for
+    entityType: t.text().notNull(), // e.g., "post", "user", etc.
+    entityId: t.text().notNull(), // ID of the entity
+    
+    // What event happened
+    event: t.text().notNull(), // e.g., "created", "updated", "published", "archived"
+    
+    // Optional metadata
+    metadata: t.json().nullable(), // Additional event data
+    
+    // Who performed the action (optional)
+    performedBy: t.text().nullable(), // User ID or system identifier
+    
+    // When it happened
+    timestamp: t.timestamp().defaultNow(),
+  })),
+}));

--- a/packages/better-db/plugins/tsconfig.json
+++ b/packages/better-db/plugins/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/better-db/test/example-schema.ts
+++ b/packages/better-db/test/example-schema.ts
@@ -1,0 +1,26 @@
+import { defineDb } from "../core/src/index";
+import { commentsPlugin } from "../plugins/src/comments";
+
+// Test the defineDb DSL
+export const blogDb = defineDb(({ table }) => ({
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    body: t.text().notNull(),
+    authorId: t.text().notNull().index(),
+    published: t.boolean().defaultValue(false),
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+  
+  Author: table("author", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    email: t.text().notNull().unique(),
+    bio: t.text().nullable(),
+  })),
+}))
+// Test plugin system
+.use(commentsPlugin);
+
+export default blogDb;

--- a/packages/better-db/test/integration.test.ts
+++ b/packages/better-db/test/integration.test.ts
@@ -1,0 +1,66 @@
+// Integration test to verify the better-db API works as expected
+import { defineDb } from "../core/src/index";
+import { commentsPlugin } from "../plugins/src/comments";
+
+console.log("🧪 Testing better-db integration...");
+
+// Test the defineDb DSL
+const blogDb = defineDb(({ table }) => ({
+  Post: table("post", (t) => ({
+    id: t.id().primaryKey(),
+    title: t.text().notNull(),
+    body: t.text().notNull(),
+    authorId: t.text().notNull().index(),
+    published: t.boolean().defaultValue(false),
+    createdAt: t.timestamp().defaultNow(),
+    updatedAt: t.timestamp().defaultNow(),
+  })),
+  
+  Author: table("author", (t) => ({
+    id: t.id().primaryKey(),
+    name: t.text().notNull(),
+    email: t.text().notNull().unique(),
+    bio: t.text().nullable(),
+  })),
+}))
+// Test plugin system
+.use(commentsPlugin);
+
+// Test schema extraction
+const schema = blogDb.getSchema();
+console.log("✅ Schema generated successfully");
+console.log("Tables:", Object.keys(schema));
+
+// Verify the Post table was created correctly
+const postTable = schema.Post;
+if (!postTable) {
+  throw new Error("Post table not found!");
+}
+
+console.log("✅ Post table fields:", Object.keys(postTable.fields));
+
+// Verify the plugin added the Comment table
+const commentTable = schema.Comment;
+if (!commentTable) {
+  throw new Error("Comment table from plugin not found!");
+}
+
+console.log("✅ Comment table from plugin:", Object.keys(commentTable.fields));
+
+// Test Better Auth schema conversion
+const betterAuthSchema = blogDb.toBetterAuthSchema();
+console.log("✅ Better Auth schema conversion successful");
+console.log("BA Schema tables:", Object.keys(betterAuthSchema));
+
+// Verify field attributes are correct
+const postIdField = postTable.fields.id;
+if (!postIdField || postIdField.type !== "string") {
+  throw new Error("Post id field incorrect!");
+}
+
+if (!postIdField.primaryKey) {
+  throw new Error("Post id should be primary key!");
+}
+
+console.log("✅ All tests passed!");
+console.log("🎉 better-db integration working correctly!");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,6 +962,140 @@ importers:
         specifier: ^3.5.18
         version: 3.5.19(typescript@5.9.2)
 
+  packages/better-db/adapter-drizzle:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+      drizzle-orm:
+        specifier: ^0.30.0
+        version: 0.30.10(@cloudflare/workers-types@4.20250903.0)(@libsql/client@0.15.14)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(@types/react@19.1.12)(better-sqlite3@12.2.0)(bun-types@1.2.21(@types/react@19.1.12))(kysely@0.28.5)(mysql2@3.14.4)(pg@8.16.3)(postgres@3.4.7)(react@19.1.1)
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/adapter-kysely:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+      kysely:
+        specifier: ^0.27.0
+        version: 0.27.6
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/adapter-memory:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/adapter-mongodb:
+    dependencies:
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+      mongodb:
+        specifier: ^6.0.0
+        version: 6.18.0
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/adapter-prisma:
+    dependencies:
+      '@prisma/client':
+        specifier: ^5.0.0
+        version: 5.22.0(prisma@5.22.0)
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/cli:
+    dependencies:
+      '@better-auth/cli':
+        specifier: workspace:*
+        version: link:../../cli
+      '@better-db/core':
+        specifier: workspace:*
+        version: link:../core
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/core:
+    dependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../../core
+      better-auth:
+        specifier: workspace:*
+        version: link:../../better-auth
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
+  packages/better-db/plugins:
+    dependencies:
+      '@better-db/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(sass@1.90.0)(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
+
   packages/cli:
     dependencies:
       '@babel/core':
@@ -7261,6 +7395,86 @@ packages:
     resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
     hasBin: true
 
+  drizzle-orm@0.30.10:
+    resolution: {integrity: sha512-IRy/QmMWw9lAQHpwbUh1b8fcn27S/a9zMIzqea1WNOxK9/4EB8gIo+FZWLiPXzl2n9ixGSv8BhsLZiOppWEwBw==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=3'
+      '@electric-sql/pglite': '>=0.1.1'
+      '@libsql/client': '*'
+      '@neondatabase/serverless': '>=0.1'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/react': '>=18'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=13.2.0'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      react: '>=18'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/react':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      react:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   drizzle-orm@0.33.0:
     resolution: {integrity: sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==}
     peerDependencies:
@@ -9054,6 +9268,10 @@ packages:
     peerDependenciesMeta:
       postgres:
         optional: true
+
+  kysely@0.27.6:
+    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
+    engines: {node: '>=14.0.0'}
 
   kysely@0.28.5:
     resolution: {integrity: sha512-rlB0I/c6FBDWPcQoDtkxi9zIvpmnV5xoIalfCMSMCa7nuA6VGA3F54TW9mEgX4DVf10sXAWCF5fDbamI/5ZpKA==}
@@ -14938,7 +15156,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15023,7 +15241,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.4
       debug: 4.4.1
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       resolve-from: 5.0.0
       semver: 7.7.2
       xml2js: 0.6.0
@@ -17180,9 +17398,7 @@ snapshots:
       metro-runtime: 0.83.1
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
@@ -19182,7 +19398,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -20228,6 +20444,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  drizzle-orm@0.30.10(@cloudflare/workers-types@4.20250903.0)(@libsql/client@0.15.14)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(@types/react@19.1.12)(better-sqlite3@12.2.0)(bun-types@1.2.21(@types/react@19.1.12))(kysely@0.28.5)(mysql2@3.14.4)(pg@8.16.3)(postgres@3.4.7)(react@19.1.1):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20250903.0
+      '@libsql/client': 0.15.14
+      '@opentelemetry/api': 1.9.0
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.5
+      '@types/react': 19.1.12
+      better-sqlite3: 12.2.0
+      bun-types: 1.2.21(@types/react@19.1.12)
+      kysely: 0.28.5
+      mysql2: 3.14.4
+      pg: 8.16.3
+      postgres: 3.4.7
+      react: 19.1.1
+
   drizzle-orm@0.33.0(@cloudflare/workers-types@4.20250903.0)(@libsql/client@0.15.14)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(@types/react@19.1.12)(better-sqlite3@12.2.0)(bun-types@1.2.21(@types/react@19.1.12))(kysely@0.28.5)(mysql2@3.14.4)(pg@8.16.3)(postgres@3.4.7)(prisma@5.22.0)(react@19.1.1):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250903.0
@@ -20744,7 +20976,7 @@ snapshots:
 
   expo-keep-awake@15.0.7(expo@54.0.10)(react@19.1.1):
     dependencies:
-      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo: 54.0.10(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.8)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.4))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-linking@7.1.7(expo@54.0.10)(react-native@0.80.2(@babel/core@7.28.4)(@react-native-community/cli@20.0.1(typescript@5.9.2))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
@@ -22203,6 +22435,8 @@ snapshots:
       kysely: 0.28.5
     optionalDependencies:
       postgres: 3.4.7
+
+  kysely@0.27.6: {}
 
   kysely@0.28.5: {}
 


### PR DESCRIPTION
Create `@better-db/*` packages as a thin, upstream-syncable fork of `better-auth`'s database layer to provide a dedicated database management library without auth domain models.

The goal is to offer `better-auth`'s robust adapter pattern, CLI-driven schema generation, and plugin system in a standalone, database-focused package. This architecture ensures easy upstream synchronization with `better-auth` while providing a clean, unopinionated API for general database use cases. The implementation includes a new `defineDb` DSL, a plugin system, and a CLI wrapper that filters out `better-auth`'s authentication-specific models during schema generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-85c52a71-54a9-41bb-935b-4783521cefe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85c52a71-54a9-41bb-935b-4783521cefe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

