### PR TITLE
fix: adapter equality bug

### DIFF
--- a/e2e/adapter/test/adapter-factory/basic.ts
+++ b/e2e/adapter/test/adapter-factory/basic.ts
@@ -3174,6 +3174,146 @@ export const getNormalTestSuiteTests = (
 				expect(result!.email).toBe(user.email);
 				expect(result!.id).toBe(user.id);
 			},
+		"findMany - eq operator with null value (single condition) should use IS NULL":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+				const withImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/avatar.png",
+					},
+					forceAllowId: true,
+				});
+
+				const nullResult = await adapter.findMany<User>({
+					model: "user",
+					where: [{ field: "image", operator: "eq", value: null }],
+				});
+				const nullIds = nullResult.map((u) => u.id);
+				expect(nullIds).toContain(withNull.id);
+				expect(nullIds).not.toContain(withImage.id);
+
+				const notNullResult = await adapter.findMany<User>({
+					model: "user",
+					where: [{ field: "image", operator: "ne", value: null }],
+				});
+				const notNullIds = notNullResult.map((u) => u.id);
+				expect(notNullIds).not.toContain(withNull.id);
+				expect(notNullIds).toContain(withImage.id);
+			},
+
+		"findMany - eq and ne operators with null value in AND group should use IS NULL / IS NOT NULL":
+			async () => {
+				const nullVerified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: null,
+						emailVerified: true,
+					},
+					forceAllowId: true,
+				});
+				const nullUnverified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: null,
+						emailVerified: false,
+					},
+					forceAllowId: true,
+				});
+				const imageVerified = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/avatar.png",
+						emailVerified: true,
+					},
+					forceAllowId: true,
+				});
+
+				// image IS NULL AND emailVerified = true → only nullVerified
+				const eqResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "eq", value: null, connector: "AND" },
+						{ field: "emailVerified", value: true, connector: "AND" },
+					],
+				});
+				const eqIds = eqResult.map((u) => u.id);
+				expect(eqIds).toContain(nullVerified.id);
+				expect(eqIds).not.toContain(nullUnverified.id);
+				expect(eqIds).not.toContain(imageVerified.id);
+
+				// image IS NOT NULL AND emailVerified = true → only imageVerified
+				const neResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "ne", value: null, connector: "AND" },
+						{ field: "emailVerified", value: true, connector: "AND" },
+					],
+				});
+				const neIds = neResult.map((u) => u.id);
+				expect(neIds).not.toContain(nullVerified.id);
+				expect(neIds).not.toContain(nullUnverified.id);
+				expect(neIds).toContain(imageVerified.id);
+			},
+
+		"findMany - eq and ne operators with null value in OR group should use IS NULL / IS NOT NULL":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+				const targetImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/target.png",
+					},
+					forceAllowId: true,
+				});
+				const otherImage = await adapter.create<User>({
+					model: "user",
+					data: {
+						...(await generate("user")),
+						image: "https://example.com/other.png",
+					},
+					forceAllowId: true,
+				});
+
+				// image IS NULL OR email = targetImage.email → withNull + targetImage
+				const eqResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "eq", value: null, connector: "OR" },
+						{ field: "email", value: targetImage.email, connector: "OR" },
+					],
+				});
+				const eqIds = eqResult.map((u) => u.id);
+				expect(eqIds).toContain(withNull.id);
+				expect(eqIds).toContain(targetImage.id);
+				expect(eqIds).not.toContain(otherImage.id);
+
+				// image IS NOT NULL OR email = withNull.email → targetImage + otherImage + withNull (by email)
+				const neResult = await adapter.findMany<User>({
+					model: "user",
+					where: [
+						{ field: "image", operator: "ne", value: null, connector: "OR" },
+						{ field: "email", value: withNull.email, connector: "OR" },
+					],
+				});
+				const neIds = neResult.map((u) => u.id);
+				expect(neIds).toContain(withNull.id); // matched by email OR clause
+				expect(neIds).toContain(targetImage.id);
+				expect(neIds).toContain(otherImage.id);
+			},
 	};
 };
 

--- a/packages/btst/adapter-drizzle/package.json
+++ b/packages/btst/adapter-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-drizzle",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Drizzle adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/adapter-kysely/package.json
+++ b/packages/btst/adapter-kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-kysely",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Kysely adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/adapter-memory/package.json
+++ b/packages/btst/adapter-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-memory",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "In-memory adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/adapter-mongodb/package.json
+++ b/packages/btst/adapter-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-mongodb",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MongoDB adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/adapter-prisma/package.json
+++ b/packages/btst/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-prisma",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Prisma adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/cli/package.json
+++ b/packages/btst/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLI for btst schema generation and migration",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/db/package.json
+++ b/packages/btst/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/db",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Core database utilities and schema definition for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/plugins/package.json
+++ b/packages/btst/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/plugins",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Plugin utilities and common plugins for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -227,9 +227,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						return [gte(schemaModel[field], w.value)];
 					}
 
-				return [w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value)];
-			}
-			const andGroup = where.filter(
+					return [
+						w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value),
+					];
+				}
+				const andGroup = where.filter(
 					(w) => w.connector === "AND" || !w.connector,
 				);
 				const orGroup = where.filter((w) => w.connector === "OR");
@@ -274,13 +278,15 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-					if (w.operator === "ne") {
-						return ne(schemaModel[field], w.value);
-					}
-					return w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value);
-				}),
-			);
-			const orClause = or(
+						if (w.operator === "ne") {
+							return ne(schemaModel[field], w.value);
+						}
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
+					}),
+				);
+				const orClause = or(
 					...orGroup.map((w) => {
 						const field = getFieldName({ model, field: w.field });
 						if (w.operator === "in") {
@@ -320,14 +326,16 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-					if (w.operator === "ne") {
-						return ne(schemaModel[field], w.value);
-					}
-					return w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value);
-				}),
-			);
+						if (w.operator === "ne") {
+							return ne(schemaModel[field], w.value);
+						}
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
+					}),
+				);
 
-			const clause: SQL<unknown>[] = [];
+				const clause: SQL<unknown>[] = [];
 
 				if (andGroup.length) clause.push(andClause!);
 				if (orGroup.length) clause.push(orClause!);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -19,6 +19,7 @@ import {
 	gt,
 	gte,
 	inArray,
+	isNull,
 	like,
 	lt,
 	lte,
@@ -226,9 +227,9 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						return [gte(schemaModel[field], w.value)];
 					}
 
-					return [eq(schemaModel[field], w.value)];
-				}
-				const andGroup = where.filter(
+				return [w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value)];
+			}
+			const andGroup = where.filter(
 					(w) => w.connector === "AND" || !w.connector,
 				);
 				const orGroup = where.filter((w) => w.connector === "OR");
@@ -273,13 +274,13 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
-						}
-						return eq(schemaModel[field], w.value);
-					}),
-				);
-				const orClause = or(
+					if (w.operator === "ne") {
+						return ne(schemaModel[field], w.value);
+					}
+					return w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value);
+				}),
+			);
+			const orClause = or(
 					...orGroup.map((w) => {
 						const field = getFieldName({ model, field: w.field });
 						if (w.operator === "in") {
@@ -319,14 +320,14 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
-						}
-						return eq(schemaModel[field], w.value);
-					}),
-				);
+					if (w.operator === "ne") {
+						return ne(schemaModel[field], w.value);
+					}
+					return w.value === null ? isNull(schemaModel[field]) : eq(schemaModel[field], w.value);
+				}),
+			);
 
-				const clause: SQL<unknown>[] = [];
+			const clause: SQL<unknown>[] = [];
 
 				if (andGroup.length) clause.push(andClause!);
 				if (orGroup.length) clause.push(orClause!);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -217,7 +217,11 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					}
 
 					if (w.operator === "ne") {
-						return [w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value)];
+						return [
+							w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value),
+						];
 					}
 
 					if (w.operator === "gt") {
@@ -279,15 +283,17 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-					if (w.operator === "ne") {
-						return w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value);
-					}
-					return w.value === null
-						? isNull(schemaModel[field])
-						: eq(schemaModel[field], w.value);
-				}),
-			);
-			const orClause = or(
+						if (w.operator === "ne") {
+							return w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value);
+						}
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
+					}),
+				);
+				const orClause = or(
 					...orGroup.map((w) => {
 						const field = getFieldName({ model, field: w.field });
 						if (w.operator === "in") {
@@ -327,16 +333,18 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-					if (w.operator === "ne") {
-						return w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value);
-					}
-					return w.value === null
-						? isNull(schemaModel[field])
-						: eq(schemaModel[field], w.value);
-				}),
-			);
+						if (w.operator === "ne") {
+							return w.value === null
+								? isNotNull(schemaModel[field])
+								: ne(schemaModel[field], w.value);
+						}
+						return w.value === null
+							? isNull(schemaModel[field])
+							: eq(schemaModel[field], w.value);
+					}),
+				);
 
-			const clause: SQL<unknown>[] = [];
+				const clause: SQL<unknown>[] = [];
 
 				if (andGroup.length) clause.push(andClause!);
 				if (orGroup.length) clause.push(orClause!);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -19,6 +19,7 @@ import {
 	gt,
 	gte,
 	inArray,
+	isNotNull,
 	isNull,
 	like,
 	lt,
@@ -216,7 +217,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					}
 
 					if (w.operator === "ne") {
-						return [ne(schemaModel[field], w.value)];
+						return [w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value)];
 					}
 
 					if (w.operator === "gt") {
@@ -278,15 +279,15 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
-						}
-						return w.value === null
-							? isNull(schemaModel[field])
-							: eq(schemaModel[field], w.value);
-					}),
-				);
-				const orClause = or(
+					if (w.operator === "ne") {
+						return w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value);
+					}
+					return w.value === null
+						? isNull(schemaModel[field])
+						: eq(schemaModel[field], w.value);
+				}),
+			);
+			const orClause = or(
 					...orGroup.map((w) => {
 						const field = getFieldName({ model, field: w.field });
 						if (w.operator === "in") {
@@ -326,16 +327,16 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						if (w.operator === "gte") {
 							return gte(schemaModel[field], w.value);
 						}
-						if (w.operator === "ne") {
-							return ne(schemaModel[field], w.value);
-						}
-						return w.value === null
-							? isNull(schemaModel[field])
-							: eq(schemaModel[field], w.value);
-					}),
-				);
+					if (w.operator === "ne") {
+						return w.value === null ? isNotNull(schemaModel[field]) : ne(schemaModel[field], w.value);
+					}
+					return w.value === null
+						? isNull(schemaModel[field])
+						: eq(schemaModel[field], w.value);
+				}),
+			);
 
-				const clause: SQL<unknown>[] = [];
+			const clause: SQL<unknown>[] = [];
 
 				if (andGroup.length) clause.push(andClause!);
 				if (orGroup.length) clause.push(orClause!);

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -186,13 +186,13 @@ export const kyselyAdapter = (
 							return eb(f, "like", `%${value}`);
 						}
 
-						if (operator === "eq") {
-							return eb(f, "=", value);
-						}
+					if (operator === "eq") {
+						return value === null ? eb(f, "is", null) : eb(f, "=", value);
+					}
 
-						if (operator === "ne") {
-							return eb(f, "<>", value);
-						}
+					if (operator === "ne") {
+						return value === null ? eb(f, "is not", null) : eb(f, "<>", value);
+					}
 
 						if (operator === "gt") {
 							return eb(f, ">", value);

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -186,13 +186,15 @@ export const kyselyAdapter = (
 							return eb(f, "like", `%${value}`);
 						}
 
-					if (operator === "eq") {
-						return value === null ? eb(f, "is", null) : eb(f, "=", value);
-					}
+						if (operator === "eq") {
+							return value === null ? eb(f, "is", null) : eb(f, "=", value);
+						}
 
-					if (operator === "ne") {
-						return value === null ? eb(f, "is not", null) : eb(f, "<>", value);
-					}
+						if (operator === "ne") {
+							return value === null
+								? eb(f, "is not", null)
+								: eb(f, "<>", value);
+						}
 
 						if (operator === "gt") {
 							return eb(f, ">", value);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `findMany` translates `eq`/`ne` comparisons against `null`, which can alter query results across supported databases if callers previously relied on `=`/`<>` behavior with nulls.
> 
> **Overview**
> Fixes adapter filtering so `where` clauses using `operator: "eq"`/`"ne"` with `value: null` generate SQL `IS NULL`/`IS NOT NULL` instead of `=`/`<>` in both the Drizzle and Kysely adapters.
> 
> Adds end-to-end adapter tests covering null comparisons for single conditions and mixed `AND`/`OR` groups, and bumps `@btst/*` package versions from `2.1.0` to `2.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d687b074b2c9fe74489b847ebb5fe4d714e44e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->