### PR TITLE
fix(kysely-adapter): followup

### DIFF
--- a/e2e/adapter/test/adapter-factory/basic.ts
+++ b/e2e/adapter/test/adapter-factory/basic.ts
@@ -3314,6 +3314,30 @@ export const getNormalTestSuiteTests = (
 				expect(neIds).toContain(targetImage.id);
 				expect(neIds).toContain(otherImage.id);
 			},
+
+		"update - should return updated record when where condition uses null value":
+			async () => {
+				const withNull = await adapter.create<User>({
+					model: "user",
+					data: { ...(await generate("user")), image: null },
+					forceAllowId: true,
+				});
+
+				// Update WHERE image IS NULL AND id = withNull.id
+				const result = await adapter.update<User>({
+					model: "user",
+					where: [
+						{ field: "id", value: withNull.id },
+						{ field: "image", operator: "eq", value: null },
+					],
+					update: { name: "null-where-updated" },
+				});
+
+				// On MySQL the re-fetch after UPDATE must use IS NULL, not = NULL
+				expect(result).toBeDefined();
+				expect(result!.id).toBe(withNull.id);
+				expect(result!.name).toBe("null-where-updated");
+			},
 	};
 };
 

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -122,12 +122,17 @@ export const kyselyAdapter = (
 						return res;
 					}
 
-					const value = values[field] || where[0]?.value;
+					const value =
+						values[field] !== undefined ? values[field] : where[0]?.value;
 					res = await db
 						.selectFrom(model)
 						.selectAll()
 						.orderBy(getFieldName({ model, field }), "desc")
-						.where(getFieldName({ model, field }), "=", value)
+						.where(
+							getFieldName({ model, field }),
+							value === null ? "is" : "=",
+							value,
+						)
 						.limit(1)
 						.executeTakeFirst();
 					return res;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches MySQL-specific `create`/`update` return-path logic in the Kysely adapter; incorrect handling could cause missing/incorrect records to be returned after writes, especially when `NULL` is involved.
> 
> **Overview**
> Fixes the Kysely adapter’s MySQL `withReturning` re-fetch logic to correctly handle *falsy* values and `NULL` in the lookup key. It now prefers `values[field]` when it is explicitly present (not just truthy) and uses `IS NULL` instead of `= NULL` when re-selecting rows.
> 
> Adds an e2e regression test ensuring `adapter.update` returns the updated record when the `where` clause includes an `eq null` condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a103a8f672e8f54948363e61be01ae607e9dddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->