### PR TITLE
chore: remove npm update step from better-db-release workflow

### DIFF
--- a/.github/workflows/better-db-release.yml
+++ b/.github/workflows/better-db-release.yml
@@ -25,9 +25,6 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-      
       - run: pnpm install
 
       - name: Build packages


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that removes a redundant `npm install -g npm@latest` step; impact is limited to release workflow behavior if builds relied on that npm version.
> 
> **Overview**
> Simplifies the `better-db-release` GitHub Actions workflow by removing the step that globally updates npm before running `pnpm install`.
> 
> This reduces tooling churn during releases while leaving the install/build/publish flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9231011178fa11d7c4322a967be03ba59f39dfaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->