### PR TITLE
chore: update npm to version 10.9.7 in better-db-release workflow

### DIFF
--- a/.github/workflows/better-db-release.yml
+++ b/.github/workflows/better-db-release.yml
@@ -25,6 +25,9 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm
+        run: npm install -g npm@10.9.7
+
       - run: pnpm install
 
       - name: Build packages


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just pins the npm CLI version used during the release workflow.
> 
> **Overview**
> Updates the `better-db-release` GitHub Actions workflow to explicitly install/pin npm `10.9.7` after `setup-node`, before running `pnpm install` and the build/publish steps, to make release runs use a consistent npm version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f454aeb59d35e656200ca38aa9d91def146a793a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->