### PR TITLE
fix: release flow

### DIFF
--- a/.github/workflows/better-db-release.yml
+++ b/.github/workflows/better-db-release.yml
@@ -22,11 +22,11 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22.x
+          node-version: 22.22.1
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@10.9.7
+        run: npm install -g npm@latest
 
       - run: pnpm install
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release/publish environment (Node and npm versions), which can impact build reproducibility and npm publishing behavior.
> 
> **Overview**
> Updates the `Better DB Release` GitHub Actions workflow to pin Node.js to `22.22.1` (instead of `22.x`) and to install `npm@latest` (instead of a fixed `10.9.7`) before building/publishing packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8c21d40941dd81de593a25f159cd7af40dd97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->