### PR TITLE
chore: fix dependency drift

### DIFF
--- a/packages/btst/adapter-drizzle/package.json
+++ b/packages/btst/adapter-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-drizzle",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Drizzle adapter for btst",
   "type": "module",
   "license": "MIT",
@@ -45,12 +45,12 @@
   "peerDependencies": {
     "better-auth": ">=1.6.0",
     "@better-auth/core": ">=1.6.0",
-    "drizzle-orm": "^0.30.0"
+    "drizzle-orm": ">=0.41.0"
   },
   "devDependencies": {
     "better-auth": "workspace:*",
     "@better-auth/core": "workspace:*",
-    "drizzle-orm": "^0.38.2",
+    "drizzle-orm": "^0.45.2",
     "typescript": "catalog:",
     "unbuild": "catalog:"
   },

--- a/packages/btst/adapter-kysely/build.config.ts
+++ b/packages/btst/adapter-kysely/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
-	entries: ["src/index"],
+	entries: ["src/index", "src/node-sqlite-dialect"],
 	externals: [
 		"better-auth",
 		"@better-auth/core",

--- a/packages/btst/adapter-kysely/build.config.ts
+++ b/packages/btst/adapter-kysely/build.config.ts
@@ -8,6 +8,7 @@ export default defineBuildConfig({
 		/^@better-auth\/core\//,
 		"@btst/db",
 		"kysely",
+		"node:sqlite",
 	],
 	declaration: true,
 	rollup: {

--- a/packages/btst/adapter-kysely/package.json
+++ b/packages/btst/adapter-kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-kysely",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Kysely adapter for btst",
   "type": "module",
   "license": "MIT",
@@ -37,6 +37,16 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./node-sqlite-dialect": {
+      "import": {
+        "types": "./dist/node-sqlite-dialect.d.ts",
+        "default": "./dist/node-sqlite-dialect.mjs"
+      },
+      "require": {
+        "types": "./dist/node-sqlite-dialect.d.cts",
+        "default": "./dist/node-sqlite-dialect.cjs"
+      }
     }
   },
   "dependencies": {
@@ -44,12 +54,12 @@
   },
   "peerDependencies": {
     "better-auth": ">=1.6.0",
-    "kysely": "^0.28.0"
+    "kysely": "^0.27.0 || ^0.28.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260410.1",
     "better-auth": "workspace:*",
-    "kysely": "^0.28.5",
+    "kysely": "^0.28.14",
     "typescript": "catalog:",
     "unbuild": "catalog:"
   },

--- a/packages/btst/adapter-memory/package.json
+++ b/packages/btst/adapter-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-memory",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "In-memory adapter for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/adapter-mongodb/package.json
+++ b/packages/btst/adapter-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-mongodb",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MongoDB adapter for btst",
   "type": "module",
   "license": "MIT",
@@ -45,11 +45,12 @@
   "peerDependencies": {
     "better-auth": ">=1.6.0",
     "@better-auth/core": ">=1.6.0",
-    "mongodb": "^6.0.0"
+    "mongodb": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "better-auth": "workspace:*",
     "@better-auth/core": "workspace:*",
+    "mongodb": "^7.1.0",
     "typescript": "catalog:",
     "unbuild": "catalog:"
   },

--- a/packages/btst/adapter-prisma/package.json
+++ b/packages/btst/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/adapter-prisma",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Prisma adapter for btst",
   "type": "module",
   "license": "MIT",
@@ -45,7 +45,8 @@
   "peerDependencies": {
     "better-auth": ">=1.6.0",
     "@better-auth/core": ">=1.6.0",
-    "@prisma/client": "^5.0.0"
+    "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "better-auth": "workspace:*",

--- a/packages/btst/cli/package.json
+++ b/packages/btst/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "CLI for btst schema generation and migration",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/cli/src/index.ts
+++ b/packages/btst/cli/src/index.ts
@@ -17,7 +17,7 @@ async function main() {
 		.addCommand(generateCommand)
 		.addCommand(initCommand)
 		.addCommand(migrateCommand)
-		.version("2.0.3")
+		.version("2.2.1")
 		.description("Better DB CLI - Database utilities without auth domain")
 		.action(() => program.help());
 

--- a/packages/btst/db/package.json
+++ b/packages/btst/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/db",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Core database utilities and schema definition for btst",
   "type": "module",
   "license": "MIT",

--- a/packages/btst/plugins/package.json
+++ b/packages/btst/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/plugins",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Plugin utilities and common plugins for btst",
   "type": "module",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -976,8 +976,8 @@ importers:
         specifier: workspace:*
         version: link:../../better-auth
       drizzle-orm:
-        specifier: ^0.38.2
-        version: 0.38.4(@cloudflare/workers-types@4.20260410.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/react@19.2.14)(better-sqlite3@12.6.2)(bun-types@1.3.9)(kysely@0.28.14)(mysql2@3.18.2(@types/node@25.5.2))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260410.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(gel@2.2.0)(kysely@0.28.14)(mysql2@3.18.2(@types/node@25.5.2))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -998,7 +998,7 @@ importers:
         specifier: workspace:*
         version: link:../../better-auth
       kysely:
-        specifier: ^0.28.5
+        specifier: ^0.28.14
         version: 0.28.14
       typescript:
         specifier: 'catalog:'
@@ -1034,9 +1034,6 @@ importers:
       '@btst/db':
         specifier: workspace:*
         version: link:../db
-      mongodb:
-        specifier: ^6.0.0
-        version: 6.21.0(socks@2.8.7)
     devDependencies:
       '@better-auth/core':
         specifier: workspace:*
@@ -1044,6 +1041,9 @@ importers:
       better-auth:
         specifier: workspace:*
         version: link:../../better-auth
+      mongodb:
+        specifier: ^7.1.0
+        version: 7.1.0(socks@2.8.7)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1057,8 +1057,11 @@ importers:
         specifier: workspace:*
         version: link:../db
       '@prisma/client':
-        specifier: ^5.0.0
-        version: 5.22.0(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
+        version: 7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      prisma:
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
+        version: 7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
     devDependencies:
       '@better-auth/core':
         specifier: workspace:*
@@ -7538,9 +7541,6 @@ packages:
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
-  '@types/whatwg-url@11.0.5':
-    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
-
   '@types/whatwg-url@13.0.0':
     resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
@@ -8256,10 +8256,6 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
-
-  bson@6.10.4:
-    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
-    engines: {node: '>=16.20.1'}
 
   bson@7.2.0:
     resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
@@ -12317,39 +12313,9 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  mongodb-connection-string-url@3.0.2:
-    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
-
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
-
-  mongodb@6.21.0:
-    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
-    engines: {node: '>=16.20.1'}
-    peerDependencies:
-      '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
-      gcp-metadata: ^5.2.0
-      kerberos: ^2.0.1
-      mongodb-client-encryption: '>=6.0.0 <7'
-      snappy: ^7.3.2
-      socks: ^2.7.1
-    peerDependenciesMeta:
-      '@aws-sdk/credential-providers':
-        optional: true
-      '@mongodb-js/zstd':
-        optional: true
-      gcp-metadata:
-        optional: true
-      kerberos:
-        optional: true
-      mongodb-client-encryption:
-        optional: true
-      snappy:
-        optional: true
-      socks:
-        optional: true
 
   mongodb@7.1.0:
     resolution: {integrity: sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==}
@@ -22418,10 +22384,6 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
-  '@types/whatwg-url@11.0.5':
-    dependencies:
-      '@types/webidl-conversions': 7.0.3
-
   '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
@@ -23374,8 +23336,6 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
-
-  bson@6.10.4: {}
 
   bson@7.2.0: {}
 
@@ -24547,25 +24507,6 @@ snapshots:
       bun-types: 1.3.9
       kysely: 0.28.14
       mysql2: 3.18.2(@types/node@20.19.39)
-      pg: 8.19.0
-      postgres: 3.4.8
-      prisma: 7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      react: 19.2.4
-
-  drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260410.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/react@19.2.14)(better-sqlite3@12.6.2)(bun-types@1.3.9)(kysely@0.28.14)(mysql2@3.18.2(@types/node@25.5.2))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react@19.2.4):
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260410.1
-      '@electric-sql/pglite': 0.3.15
-      '@libsql/client': 0.17.0(encoding@0.1.13)
-      '@opentelemetry/api': 1.9.0
-      '@prisma/client': 7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
-      '@types/better-sqlite3': 7.6.13
-      '@types/pg': 8.16.0
-      '@types/react': 19.2.14
-      better-sqlite3: 12.6.2
-      bun-types: 1.3.9
-      kysely: 0.28.14
-      mysql2: 3.18.2(@types/node@25.5.2)
       pg: 8.19.0
       postgres: 3.4.8
       prisma: 7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -28360,23 +28301,10 @@ snapshots:
   module-details-from-path@1.0.4:
     optional: true
 
-  mongodb-connection-string-url@3.0.2:
-    dependencies:
-      '@types/whatwg-url': 11.0.5
-      whatwg-url: 14.2.0
-
   mongodb-connection-string-url@7.0.1:
     dependencies:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
-
-  mongodb@6.21.0(socks@2.8.7):
-    dependencies:
-      '@mongodb-js/saslprep': 1.4.6
-      bson: 6.10.4
-      mongodb-connection-string-url: 3.0.2
-    optionalDependencies:
-      socks: 2.8.7
 
   mongodb@7.1.0(socks@2.8.7):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly packaging/dependency changes, but expanding peer ranges (Drizzle/MongoDB/Prisma) and adding a new `node:sqlite` dialect entrypoint could surface compatibility or bundling issues for consumers.
> 
> **Overview**
> Bumps the `@btst/*` package versions to `2.2.1` and updates the CLI-reported version to match.
> 
> Aligns adapter dependency expectations by widening/raising peer ranges (notably `drizzle-orm` to `>=0.41.0`, `mongodb` to support v6/v7, and Prisma to support v5–v7 and include `prisma` as a peer), and updates lockfile resolutions accordingly.
> 
> Adds a new `@btst/adapter-kysely/node-sqlite-dialect` export, includes it in the build outputs, and marks `node:sqlite` as external for bundling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19dc205b98f8577bf15b06d83a02a510e22ab1c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->